### PR TITLE
Make sure that attributes aren't put in closing keys

### DIFF
--- a/lib/puppet/functions/hash_to_xml.rb
+++ b/lib/puppet/functions/hash_to_xml.rb
@@ -15,7 +15,7 @@ Puppet::Functions.create_function(:hash_to_xml) do
     output += calc_indent(level)
     output +="<#{k}>" if open
     output += v if (open and close)
-    output += "</#{k}>" if close
+    output += "</#{k.split(/\s/, 2)[0]}>" if close
     output += "\n"
   end
 


### PR DESCRIPTION
The function would produce invalid XML with attributes in closing tags.
For example:

<?xml version="1.0" encoding="UTF-8"?>
<Root version="3">
</Root version="3">